### PR TITLE
Add payment flow with order storage

### DIFF
--- a/cart/app.js
+++ b/cart/app.js
@@ -2,6 +2,8 @@
 const CURRENCY = "฿";
 const IMG_FALLBACK = "/img/products/box.png";
 const CART_KEY = "cart";
+const ORDERS_KEY = "orders";
+const PAYMENT_LABELS = { transfer: "โอนเงิน", cod: "เก็บเงินปลายทาง" };
 
 const fmt = (n) => `${CURRENCY}${Number(n || 0).toLocaleString()}`;
 
@@ -155,15 +157,16 @@ checkoutBtn?.addEventListener("click", () => {
     return;
   }
 
-  // ตัวอย่าง summary + พร้อมส่งไป backend ได้
+  const payment = document.querySelector('input[name="payment"]:checked')?.value || "transfer";
+
   const summary = cart.map(i => `${i.name}${i.variant ? ` (${i.variant})` : ""} x ${i.quantity}`).join("\n");
   const total = cart.reduce((sum, i) => sum + (i.price * i.quantity), 0);
 
-  alert(`คุณสั่งสินค้า:\n${summary}\nรวมทั้งหมด: ${fmt(total)}`);
+  const orders = JSON.parse(localStorage.getItem(ORDERS_KEY) || "[]");
+  orders.push({ items: cart, payment, createdAt: new Date().toISOString() });
+  localStorage.setItem(ORDERS_KEY, JSON.stringify(orders));
 
-  // TODO: เรียก API สร้างออเดอร์ -> ส่ง cart ไป backend
-  // fetch(`${API_BASE}/orders`, { method:'POST', headers:{'Content-Type':'application/json','Authorization':`Bearer ${jwtToken}`}, body: JSON.stringify({items: cart}) })
-
+  alert(`คุณสั่งสินค้า:\n${summary}\nรวมทั้งหมด: ${fmt(total)}\nชำระด้วย: ${PAYMENT_LABELS[payment]}`);
   cart = [];
   localStorage.removeItem(CART_KEY);
   renderCart();

--- a/cart/index.html
+++ b/cart/index.html
@@ -81,6 +81,11 @@ button {
       </thead>
       <tbody id="cart-list"></tbody>
     </table>
+    <div id="payment-methods" style="margin-top:20px;">
+      <strong>วิธีชำระเงิน:</strong>
+      <label style="margin-left:10px;"><input type="radio" name="payment" value="transfer" checked> โอนเงิน</label>
+      <label style="margin-left:10px;"><input type="radio" name="payment" value="cod"> เก็บเงินปลายทาง</label>
+    </div>
     <p class="total" id="total">รวมทั้งหมด: 0฿</p>
     <div style="text-align:right; margin-top:10px;">
       <button class="clear-btn" id="clear-cart">ล้างตะกร้า</button>

--- a/office/cart/index.html
+++ b/office/cart/index.html
@@ -1,11 +1,57 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="th">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CART หลังบ้าน</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>รับออเดอร์</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 20px; }
+    table { width: 100%; border-collapse: collapse; margin-top: 20px; }
+    th, td { border: 1px solid #ccc; padding: 8px; text-align: left; }
+    th { background: #f0f0f0; }
+    #clear-orders { margin-top: 15px; }
+  </style>
 </head>
 <body>
-    
+  <h1>รายการสั่งซื้อ</h1>
+  <table>
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>สินค้า</th>
+        <th>ชำระเงิน</th>
+        <th>เวลา</th>
+      </tr>
+    </thead>
+    <tbody id="orders-body"></tbody>
+  </table>
+  <button id="clear-orders">ลบทั้งหมด</button>
+
+  <script>
+    const PAYMENT_LABELS = { transfer: "โอนเงิน", cod: "เก็บเงินปลายทาง" };
+    function loadOrders() {
+      try {
+        return JSON.parse(localStorage.getItem("orders")) || [];
+      } catch {
+        return [];
+      }
+    }
+    const orders = loadOrders();
+    const body = document.getElementById("orders-body");
+    if (orders.length === 0) {
+      body.innerHTML = "<tr><td colspan='4'>ไม่มีออเดอร์</td></tr>";
+    } else {
+      orders.forEach((o, idx) => {
+        const items = o.items.map(i => `${i.name}${i.variant ? ` (${i.variant})` : ""} x ${i.quantity}`).join(", ");
+        const tr = document.createElement("tr");
+        tr.innerHTML = `<td>${idx + 1}</td><td>${items}</td><td>${PAYMENT_LABELS[o.payment] || o.payment}</td><td>${new Date(o.createdAt).toLocaleString()}</td>`;
+        body.appendChild(tr);
+      });
+    }
+    document.getElementById("clear-orders").addEventListener("click", () => {
+      localStorage.removeItem("orders");
+      location.reload();
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add payment method selector to cart
- save orders with payment method to localStorage
- display submitted orders in admin cart page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a58066acf483288ff0153cdd50b412